### PR TITLE
Speed improvement of Tokenizer

### DIFF
--- a/pydifact/control/characters.py
+++ b/pydifact/control/characters.py
@@ -46,6 +46,8 @@ class Characters:
         # The control character used as an segment terminator.
         self.segment_terminator = "'"
 
+        self.line_terminators = [" ", "\r", "\n"]
+
     @classmethod
     def from_str(cls, string: str) -> "Characters":
         """Returns a new instance with control characters set to given string.

--- a/pydifact/segments.py
+++ b/pydifact/segments.py
@@ -28,7 +28,7 @@ class Segment:
         :param str tag: The code/tag of the segment.
         :param list elements: The data elements for this segment, as list.
         """
-        assert type(tag) == str
+        assert type(tag) == str, "%s is not a str, it is %s" % (tag, type(tag),)
         self.tag = tag
 
         """The data elements for this segment.

--- a/pydifact/serializer.py
+++ b/pydifact/serializer.py
@@ -41,35 +41,37 @@ class Serializer:
         :param with_una: True if a UNA header should be written. Defauts to False.
         """
 
-        message = ""
+        message_parts = []
 
         if with_una:
             # create an EDIFACT header
-            message = "UNA"
-            message += self.characters.component_separator
-            message += self.characters.data_separator
-            message += self.characters.decimal_point
-            message += self.characters.escape_character
-            message += self.characters.reserved_character
-            message += self.characters.segment_terminator
+            message_parts = ["UNA",
+                             self.characters.component_separator,
+                             self.characters.data_separator,
+                             self.characters.decimal_point,
+                             self.characters.escape_character,
+                             self.characters.reserved_character,
+                             self.characters.segment_terminator,
+                             ]
 
         # iter through all segments
         for segment in segments:
             # skip the UNA segment as we already have written it if requested
             if segment.tag == "UNA":
                 continue
-            message += segment.tag
+            message_parts += [segment.tag]
             for element in segment.elements:
-                message += self.characters.data_separator
+                message_parts += [self.characters.data_separator]
                 if type(element) == list:
                     for nr, subelement in enumerate(element):
                         element[nr] = self.escape(subelement)
-                    message += self.characters.component_separator.join(element)
+                    message_parts += [self.characters.component_separator.join(element)]
                 else:
-                    message += self.escape(element)
+                    message_parts += [self.escape(element)]
 
-            message += self.characters.segment_terminator
+            message_parts += [self.characters.segment_terminator]
 
+        message = "".join(message_parts)
         return message
 
     def escape(self, string: str or None) -> str:
@@ -80,7 +82,7 @@ class Serializer:
 
         if string is None:
             return ""
-        assert type(string) == str
+        assert type(string) == str, "%s is not a str, it is %s" % (string, type(string),)
 
         characters = [
             self.characters.escape_character,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,2 @@
 nose
+pytest

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,7 +103,7 @@ def _assert_segments(parser, default_una_segment, message: str, segments: list):
     result = list(parser.parse(input_str))
     print("input segments: {}".format(segments[0]))
     print("parser result:  {}".format(result[0]))
-    assert ([default_una_segment] + segments, result)
+    assert [default_una_segment] + segments, result
 
 
 def test_compare_equal_segments(parser, default_una_segment):


### PR DESCRIPTION
This is related to #2 

I took a look at the Tokenizer, since it's basically the component that has to tool at each character.
Unless I am wrong :)

The Tokenizer had especially in get_next_token() a few calls that made python create with each iteration a new instance of things like lists.
```[" ", "\r", "\n"]``` was one of this. https://github.com/nerdocs/pydifact/blob/master/pydifact/tokenizer.py#L121

I also simplified the long conditional cases in that function, so you have a dictionary now in that class called ```token_selector``` imho, this makes it a bit better readable and easier to extend.

the stored chars are a list now instead of a string. I used "".join(seq) whenever possible because of best practice.

The hugefile test dropped for me by almost 1 second with those changes.

I added pytest to the requirements, because the tests needs it for the fixtures.