### PR TITLE
setup.cfg wasn't read by python setup.py as intended.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[options]
+packages = pydifact, pydifact.control
+
 [metadata]
 name = pydifact
 version = attr:pydifact.__version__
@@ -6,9 +9,6 @@ author_email = christian.gonzalez@nerdocs.at
 description = A Python EDI file parser.
 # install_requires=[]
 url = https://github.com/nerdocs/pydifact
-packages =
-    pydifact
-    pydifact.control
 license = MIT
 classifiers =
     Development Status :: 3 - Alpha


### PR DESCRIPTION
Moved the **packages** keyword to _[options]_ section
See docs: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files