### PR TITLE
Bug fixes

### DIFF
--- a/pydifact/parser.py
+++ b/pydifact/parser.py
@@ -193,7 +193,12 @@ class Parser:
 
             # here we can be sure that the token value is normal "content"
             # first backfill empty strings for skipped component data (:::)
-            for i in range(1, empty_component_counter):
+            for i in range(
+                1,
+                empty_component_counter
+                if data_element
+                else empty_component_counter + 1,
+            ):
                 data_element.append("")
 
             data_element.append(token.value)

--- a/pydifact/serializer.py
+++ b/pydifact/serializer.py
@@ -69,8 +69,7 @@ class Serializer:
             for element in segment.elements:
                 message_parts += [self.characters.data_separator]
                 if type(element) == list:
-                    for nr, subelement in enumerate(element):
-                        element[nr] = self.escape(subelement)
+                    element = (self.escape(subelement) for subelement in element)
                     message_parts += [self.characters.component_separator.join(element)]
                 else:
                     message_parts += [self.escape(element)]

--- a/pydifact/tokenizer.py
+++ b/pydifact/tokenizer.py
@@ -111,7 +111,7 @@ class Tokenizer:
         # If we're not escaping this character then see if it's
         # a control character
 
-        token_type = self.token_selector.get(self._char)
+        token_type = not self.isEscaped and self.token_selector.get(self._char)
         if token_type:
             self.store_current_char_and_read_next()
             token = Token(token_type, self.extract_stored_chars())

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,7 +38,7 @@ def parser():
 
 @pytest.fixture
 def default_una_segment():
-    return Segment("UNA", list(":+,? '"))
+    return Segment("UNA", ":+,? '")
 
 
 # def get_control_characters(mocker, parser, message: str, tokenizer=None) -> Characters:
@@ -103,7 +103,7 @@ def _assert_segments(parser, default_una_segment, message: str, segments: list):
     result = list(parser.parse(input_str))
     print("input segments: {}".format(segments[0]))
     print("parser result:  {}".format(result[0]))
-    assert [default_una_segment] + segments, result
+    assert [default_una_segment] + segments == result
 
 
 def test_compare_equal_segments(parser, default_una_segment):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -207,3 +207,24 @@ def test_escape_sequence(parser, default_una_segment):
         "ERC+10:?:?+???' - ?:?+???' - ?:?+???'",
         [Segment("ERC", ["10", ":+?' - :+?' - :+?'"])],
     )
+
+
+def test_compound_starts_with_skipped(parser, default_una_segment):
+
+    _assert_segments(
+        parser, default_una_segment, "IMD+::A", [Segment("IMD", ["", "", "A"])]
+    )
+
+
+def test_compound_contains_one_skipped(parser, default_una_segment):
+
+    _assert_segments(
+        parser, default_una_segment, "IMD+A::B", [Segment("IMD", ["A", "", "B"])]
+    )
+
+
+def test_compound_contains_two_skipped(parser, default_una_segment):
+
+    _assert_segments(
+        parser, default_una_segment, "IMD+A:::B", [Segment("IMD", ["A", "", "", "B"])]
+    )

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -13,6 +13,7 @@
 #
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import copy
 import pytest
 
 from pydifact.message import Message
@@ -99,3 +100,10 @@ def test_escape_sequence(serializer):
         "ERC+10:?:?+???' - ?:?+???' - ?:?+???'",
         [Segment("ERC", ["10", ":+?' - :+?' - :+?'"])],
     )
+
+
+def test_no_mutation(serializer):
+    segments1 = [Segment("ERC", [":+?'"])]
+    segments2 = copy.deepcopy(segments1)
+    serializer.serialize(segments1, with_una_header=True)
+    assert segments1 == segments2

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -106,6 +106,18 @@ def test_quadruple_escape():
     )
 
 
+def test_starts_with_escape():
+    _assert_tokens(
+        "DTM+?+0'",
+        [
+            Token(Token.Type.CONTENT, "DTM"),
+            Token(Token.Type.DATA_SEPARATOR, "+"),
+            Token(Token.Type.CONTENT, "+0"),
+            Token(Token.Type.TERMINATOR, "'"),
+        ],
+    )
+
+
 # This tests check if line break combinations (CR/LF) after a segment terminator are correctly ignored.
 
 


### PR DESCRIPTION
Various bug fixes.

- Tests in test_parser.py were failing, but that wasn't being detected because of a typo in _assert_segments.
- When the escape character appeared at the start of the data element, the tokenizer was not respecting the escape character.
- When a composite data element starts with empty components (eg `:::abc`), the resulting Segment had one too few empty strings in its elements list.
- After serializing a Segment whose data elements needing escaping, the strings Segment's elements array was being changed. The strings in the elements array was becoming escaped.