### PR TITLE
Use generator for tokenizing.

### DIFF
--- a/pydifact/segmentcollection.py
+++ b/pydifact/segmentcollection.py
@@ -107,7 +107,10 @@ class SegmentCollection:
     def add_segments(
         self, segments: List[Segment] or collections.Iterable
     ) -> "SegmentCollection":
-        """Add multiple segments to the collection.
+        """Add multiple segments to the collection. Passing a UNA segment means setting/overriding the control
+        characters and setting the serializer to output the Service String Advice. If you wish to change the control
+        characters from the default and not output the Service String Advice, change self.characters instead,
+        without passing a UNA Segment.
 
         :param segments: The segments to add
         :type segments: list or iterable of Segments
@@ -118,13 +121,17 @@ class SegmentCollection:
         return self
 
     def add_segment(self, segment: Segment) -> "SegmentCollection":
-        """Append a segment to the collection.
+        """Append a segment to the collection. Passing a UNA segment means setting/overriding the control
+        characters and setting the serializer to output the Service String Advice. If you wish to change the control
+        characters from the default and not output the Service String Advice, change self.characters instead,
+        without passing a UNA Segment.
 
         :param segment: The segment to add
         """
         if segment.tag == "UNA":
             self.has_una_segment = True
             self.characters = Characters.from_str(segment.elements[0])
+            return self
         self.segments.append(segment)
         return self
 
@@ -132,7 +139,9 @@ class SegmentCollection:
         """Serialize all the segments added to this object.
         :param break_lines: if True, insert line break after each segment terminator.
         """
-        return Serializer().serialize(self.segments, self.has_una_segment, break_lines)
+        return Serializer(self.characters).serialize(
+            self.segments, self.has_una_segment, break_lines
+        )
 
     def __str__(self) -> str:
         """Allow the object to be serialized by casting to a string."""

--- a/pydifact/tokenizer.py
+++ b/pydifact/tokenizer.py
@@ -71,13 +71,8 @@ class Tokenizer:
             self.characters.segment_terminator: Token.Type.TERMINATOR,
         }
 
-        tokens = []
-
         while not self.end_of_message():
-            token = self.get_next_token()
-            tokens.append(token)
-
-        return tokens
+            yield self.get_next_token()
 
     def read_next_char(self) -> None:
         """Read the next character from the message.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -95,9 +95,9 @@ def _assert_segments(parser, default_una_segment, collection: str, segments: lis
 
     input_str = "UNA:+,? '\n" + collection + "'\n"
     result = list(parser.parse(input_str))
-    print("input segments: {}".format(segments[0]))
-    print("parser result:  {}".format(result[0]))
-    assert [default_una_segment] + segments == result
+    # print("input segments: {}".format(segments[0]))
+    # print("parser result:  {}".format(result[0]))
+    assert segments == result
 
 
 def test_compare_equal_segments(parser, default_una_segment):
@@ -113,21 +113,18 @@ def test_compare_equal_segments(parser, default_una_segment):
 def test_una_parser1(parser):
     # UNA headers are a special parsing task and must be processed correctly.
     tokens = parser.parse("UNA:+,? 'TEST'")
-    assert next(tokens) == Segment("UNA", ":+,? '")
     assert next(tokens) == Segment("TEST")
 
 
 def test_una_parser2(parser):
     # UNA headers are a special parsing task and must be processed correctly.
     tokens = parser.parse("UNA123456TEST6")
-    assert next(tokens) == Segment("UNA", "123456")
     assert next(tokens) == Segment("TEST")
 
 
 def test_una_parser3(parser):
     # UNA headers are a special parsing task and must be processed correctly.
     tokens = parser.parse("UNA12345'TEST'")
-    assert next(tokens) == Segment("UNA", "12345'")
     assert next(tokens) == Segment("TEST")
 
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -33,7 +33,7 @@ def _assert_tokens(
 
     if expected is None:
         expected = []
-    tokens = Tokenizer().get_tokens(collection)
+    tokens = list(Tokenizer().get_tokens(collection))
     if error_message:
         assert expected == tokens, error_message
     else:
@@ -165,5 +165,5 @@ def test_ignore_long_whitespace(expected_crlf):
 
 def test_no_terminator():
     with pytest.raises(RuntimeError):
-        Tokenizer().get_tokens("TEST", Characters())
+        list(Tokenizer().get_tokens("TEST", Characters()))
         pytest.fail("Unexpected end of EDI message")


### PR DESCRIPTION
The main goal for these changes was to introduce a generator for the tokens and chain it with `convert_tokens_to_segments()`. My profiling had shown that the huge_file2.edi was producing about 160mb worth of tokens in a list before going into the conversion to segments (converts into ~60mb segment list).

There were some problems with how the UNA is handled before tokenizing. I could not make the changes with the manually created UNA Tokens in `parse()` because they would interfere with the generator chaining. I removed these Tokens and also removed the UNA handling from `convert_tokens_to_segments()`. It wasn't used anyway except for making an actual UNA segment. This means that there wont be any UNA segments from parsing anymore! I do not know why anyone would need such a segment after the parsing is done. Strictly speaking, the service string advice is not a segment anyway.