### PR TITLE
Add an optional predicate filter to `get_segment` and `get_segments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for PYDIFACT
 [0.1] - UNRELEASED
 - Deprecate SegmentCollection
 - Add Interchange and Message semantic and featured classes
+- Add an optional predicate filter to `get_segment` and `get_segments` methods
 
 [0.0.5] - 2020-04-29
 - corrected pypi details

--- a/pydifact/segmentcollection.py
+++ b/pydifact/segmentcollection.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 import collections
-from typing import List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 import datetime
 import warnings
 
@@ -74,22 +74,34 @@ class AbstractSegmentsContainer:
         # with the added segments
         return cls().add_segments(segments)
 
-    def get_segments(self, name: str) -> list:
+    def get_segments(
+            self, name: str, predicate: Callable[[Segment], bool] = None
+    ) -> list:
         """Get all the segments that match the requested name.
-        :param name: The name of the segment to return
+        :param name: The name of the segments to return
+        :param predicate: Optional predicate that must match on the segments
+           to return
         :rtype: list of Segment
         """
         for segment in self.segments:
-            if segment.tag == name:
+            if (
+                    segment.tag == name
+                    and
+                    (predicate is None or predicate(segment))
+            ):
                 yield segment
 
-    def get_segment(self, name: str) -> Optional[Segment]:
+    def get_segment(
+            self, name: str, predicate: Callable[[Segment], bool] = None
+    ) -> Optional[Segment]:
         """Get the first segment that matches the requested name.
 
         :return: The requested segment, or None if not found
         :param name: The name of the segment to return
+        :param predicate: Optional predicate that must match on the segments
+           to return
         """
-        for segment in self.get_segments(name):
+        for segment in self.get_segments(name, predicate):
             return segment
 
         return None

--- a/tests/test_segmentcollection.py
+++ b/tests/test_segmentcollection.py
@@ -45,6 +45,17 @@ def test_get_segments_doesnt_exist():
     segments = list(collection.get_segments("36CF"))
     assert [] == segments
 
+def test_get_segments_w_predicate():
+    collection = SegmentCollection.from_segments([
+            Segment("A", '1', 'a'),
+            Segment("A", '2', 'b'),
+            Segment("A", '1', 'c'),
+    ])
+    segments = collection.get_segments("A", lambda x: x[0] == '1')
+    assert [
+        Segment("A", '1', 'a'),
+        Segment("A", '1', 'c'),
+    ] == list(segments)
 
 def test_get_segment():
     collection = SegmentCollection.from_segments(
@@ -52,6 +63,14 @@ def test_get_segment():
     )
     segment = collection.get_segment("36CF")
     assert Segment("36CF", 1) == segment
+
+
+def test_get_segment_w_predicate():
+    collection = SegmentCollection.from_segments(
+        [Segment("36CF", '1'), Segment("36CF", '2')]
+    )
+    segment = collection.get_segment("36CF", lambda x: x[0] == '2')
+    assert segment == Segment("36CF", '2')
 
 
 def test_str_serialize():


### PR DESCRIPTION
This is a helper to ease the kind of parsing (semi-manual searching) that pydifact allows.