### PR TITLE
Allow to access container elements using list-like notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for PYDIFACT
 [0.1] - UNRELEASED
 - Deprecate SegmentCollection
 - Add Interchange and Message semantic and featured classes
+- Allow to access AbstractSegmentsContainer elements using `container[i]`
 
 [0.0.5] - 2020-04-29
 - corrected pypi details

--- a/pydifact/segments.py
+++ b/pydifact/segments.py
@@ -79,6 +79,12 @@ class Segment(SegmentProvider):
             and list(self.elements) == list(other.elements)
         )
 
+    def __getitem__(self, key):
+        return self.elements[key]
+
+    def __setitem__(self, key, value):
+        self.elements[key] = value
+
     def validate(self) -> bool:
         """
         Segment validation.


### PR DESCRIPTION
Merely a shortcut for the common use of container.elements[i]