### PR TITLE
Small tweaks to allow Python 3.5 compatibility

### DIFF
--- a/pydifact/segmentcollection.py
+++ b/pydifact/segmentcollection.py
@@ -288,7 +288,10 @@ class Message(AbstractSegmentsContainer):
 
         :return: message version, parsable by pkg_resources.parse_version()
         """
-        return f'{self.identifier[1]}.{self.identifier[2]}'
+        return "{}.{}".format(
+            self.identifier[1],
+            self.identifier[2]
+        )
 
 
     def get_header_segment(self) -> Segment:
@@ -346,7 +349,10 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
             [str(i) for i in self.syntax_identifier],
             self.sender,
             self.recipient,
-            [f'{self.timestamp:%y%m%d}', f'{self.timestamp:%H%M}'],
+            [
+                "{:%y%m%d}".format(self.timestamp),
+                "{:%H%M}".format(self.timestamp)
+            ],
             self.control_reference,
             *self.extra_header_elements,
         )
@@ -366,14 +372,14 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
                     message = Message(segment.elements[0], segment.elements[1])
                 else:
                     raise EDISyntaxError(
-                        f"Missing UNT segment before new UNH: {segment}"
+                        "Missing UNT segment before new UNH: {}".format(segment)
                     )
             elif segment.tag == 'UNT':
                 if message:
                     yield message
                 else:
                     raise EDISyntaxError(
-                        f'UNT segment without matching UNH: "{segment}"'
+                        'UNT segment without matching UNH: "{}"'.format(segment)
                     )
             else:
                 if message:

--- a/pydifact/segmentcollection.py
+++ b/pydifact/segmentcollection.py
@@ -75,24 +75,20 @@ class AbstractSegmentsContainer:
         return cls().add_segments(segments)
 
     def get_segments(
-            self, name: str, predicate: Callable[[Segment], bool] = None
+        self, name: str, predicate: Callable[[Segment], bool] = None
     ) -> list:
         """Get all the segments that match the requested name.
-        
+
         :param name: The name of the segments to return
         :param predicate: Optional predicate callable that returns True if the given segment matches a condition
         :rtype: list of Segment
         """
         for segment in self.segments:
-            if (
-                    segment.tag == name
-                    and
-                    (predicate is None or predicate(segment))
-            ):
+            if segment.tag == name and (predicate is None or predicate(segment)):
                 yield segment
 
     def get_segment(
-            self, name: str, predicate: Callable[[Segment], bool] = None
+        self, name: str, predicate: Callable[[Segment], bool] = None
     ) -> Optional[Segment]:
         """Get the first segment that matches the requested name.
 
@@ -158,7 +154,9 @@ class AbstractSegmentsContainer:
             out.append(footer)
 
         return Serializer(self.characters).serialize(
-            out, self.has_una_segment, break_lines,
+            out,
+            self.has_una_segment,
+            break_lines,
         )
 
     def __str__(self) -> str:
@@ -172,6 +170,7 @@ class FileSourcableMixin:
 
     For v0.2 drop this class and move from_file() to Interchange class.
     """
+
     @classmethod
     def from_file(cls, file: str, encoding: str = "iso8859-1") -> "FileSourcableMixin":
         """Create a Interchange instance from a file.
@@ -187,6 +186,7 @@ class FileSourcableMixin:
         with open(file, encoding=encoding) as f:
             collection = f.read()
         return cls.from_str(collection)
+
 
 class UNAHandlingMixin:
     """
@@ -210,13 +210,15 @@ class UNAHandlingMixin:
         return super().add_segment(segment)
 
 
-
-class SegmentCollection(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContainer):
+class SegmentCollection(
+    FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContainer
+):
     """
     For backward compatibility. Drop it in v0.2
 
     Will be replaced by Interchange or RawSegmentCollection depending on the need.
     """
+
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "SegmentCollection is deprecated and will no longer be available in v0.2, "
@@ -232,7 +234,7 @@ class SegmentCollection(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsCo
             "Use Interchange class instead",
             DeprecationWarning,
         )
-        return  super().from_file(*args, **kwargs)
+        return super().from_file(*args, **kwargs)
 
     def add_segment(self, segment: Segment) -> "SegmentCollection":
         if segment.tag == "UNA":
@@ -254,8 +256,8 @@ class RawSegmentCollection(AbstractSegmentsContainer):
     those classes to RawSegmentCollection, as they offer more features and
     checks.
     """
-    pass
 
+    pass
 
 
 class Message(AbstractSegmentsContainer):
@@ -267,12 +269,8 @@ class Message(AbstractSegmentsContainer):
     https://www.stylusstudio.com/edifact/40100/UNH_.htm
     https://www.stylusstudio.com/edifact/40100/UNT_.htm
     """
-    def __init__(
-            self,
-            reference_number: str,
-            identifier: Tuple,
-            *args, **kwargs
-    ):
+
+    def __init__(self, reference_number: str, identifier: Tuple, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.reference_number = reference_number
         self.identifier = identifier
@@ -288,11 +286,7 @@ class Message(AbstractSegmentsContainer):
 
         :return: message version, parsable by pkg_resources.parse_version()
         """
-        return "{}.{}".format(
-            self.identifier[1],
-            self.identifier[2]
-        )
-
+        return "{}.{}".format(self.identifier[1], self.identifier[2])
 
     def get_header_segment(self) -> Segment:
         return Segment(
@@ -325,15 +319,17 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
     https://www.stylusstudio.com/edifact/40100/UNB_.htm
     https://www.stylusstudio.com/edifact/40100/UNZ_.htm
     """
+
     def __init__(
-            self,
-            sender: str,
-            recipient: str,
-            control_reference: str,
-            syntax_identifier: Tuple[str, int],
-            delimiters: Characters = Characters(),
-            timestamp: datetime.datetime = None,
-            *args, **kwargs
+        self,
+        sender: str,
+        recipient: str,
+        control_reference: str,
+        syntax_identifier: Tuple[str, int],
+        delimiters: Characters = Characters(),
+        timestamp: datetime.datetime = None,
+        *args,
+        **kwargs
     ):
         super().__init__(*args, **kwargs)
         self.sender = sender
@@ -349,10 +345,7 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
             [str(i) for i in self.syntax_identifier],
             self.sender,
             self.recipient,
-            [
-                "{:%y%m%d}".format(self.timestamp),
-                "{:%H%M}".format(self.timestamp)
-            ],
+            ["{:%y%m%d}".format(self.timestamp), "{:%H%M}".format(self.timestamp)],
             self.control_reference,
             *self.extra_header_elements,
         )
@@ -367,14 +360,14 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
     def get_messages(self) -> List[Message]:
         message = None
         for segment in self.segments:
-            if segment.tag == 'UNH':
+            if segment.tag == "UNH":
                 if not message:
                     message = Message(segment.elements[0], segment.elements[1])
                 else:
                     raise EDISyntaxError(
                         "Missing UNT segment before new UNH: {}".format(segment)
                     )
-            elif segment.tag == 'UNT':
+            elif segment.tag == "UNT":
                 if message:
                     yield message
                 else:
@@ -395,24 +388,22 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
         return self
 
     @classmethod
-    def from_segments(
-        cls, segments: list or collections.Iterable
-    ) -> "Interchange":
+    def from_segments(cls, segments: list or collections.Iterable) -> "Interchange":
         segments = iter(segments)
 
         first_segment = next(segments)
-        if first_segment.tag == 'UNA':
+        if first_segment.tag == "UNA":
             unb = next(segments)
-        elif first_segment.tag == 'UNB':
+        elif first_segment.tag == "UNB":
             unb = first_segment
         else:
-            raise EDISyntaxError('An interchange must start with UNB or UNA and UNB')
+            raise EDISyntaxError("An interchange must start with UNB or UNA and UNB")
         # Loosy syntax check :
         if len(unb.elements) < 4:
-            raise EDISyntaxError('Missing elements in UNB header')
+            raise EDISyntaxError("Missing elements in UNB header")
 
-        datetime_str = '-'.join(unb.elements[3])
-        timestamp = datetime.datetime.strptime(datetime_str, '%y%m%d-%H%M')
+        datetime_str = "-".join(unb.elements[3])
+        timestamp = datetime.datetime.strptime(datetime_str, "%y%m%d-%H%M")
         interchange = Interchange(
             syntax_identifier=unb.elements[0],
             sender=unb.elements[1],
@@ -421,10 +412,10 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
             control_reference=unb.elements[4],
         )
 
-        if first_segment.tag == 'UNA':
+        if first_segment.tag == "UNA":
             interchange.has_una_segment = True
             interchange.characters = Characters.from_str(first_segment.elements[0])
 
         return interchange.add_segments(
-            segment for segment in segments if segment.tag != 'UNZ'
+            segment for segment in segments if segment.tag != "UNZ"
         )

--- a/pydifact/segments.py
+++ b/pydifact/segments.py
@@ -69,7 +69,10 @@ class Segment(SegmentProvider):
         )
 
     def __repr__(self) -> str:
-        return f"{self.tag} segment: {str(self.elements)}"
+        return "{} segment: {}".format(
+            self.tag,
+            str(self.elements)
+        )
 
     def __eq__(self, other) -> bool:
         # FIXME the other way round too? isinstance(other, type(self))?
@@ -128,12 +131,17 @@ class SegmentFactory:
 
         if type(name) != str:
             raise EDISyntaxError(
-                f"The tag name of a segment must be a str, but is a {type(name)}: {name}"
+                "The tag name of a segment must be a str, but is a {}: {}".format(
+                    type(name),
+                    name
+                )
             )
 
         if not name.isalnum():
             raise EDISyntaxError(
-                f"Tag '{name}': A tag name must only contain alphanumeric characters."
+                "Tag '{}': A tag name must only contain alphanumeric characters.".format(
+                    name
+                )
             )
 
         for Plugin in SegmentProvider.plugins:
@@ -147,7 +155,9 @@ class SegmentFactory:
         if validate:
             if not s.validate():
                 raise EDISyntaxError(
-                    f"could not create '{name}' Segment. Validation failed."
+                    "could not create '{}' Segment. Validation failed.".format(
+                        name
+                    )
                 )
 
         # FIXME: characters is not used!

--- a/pydifact/segments.py
+++ b/pydifact/segments.py
@@ -69,10 +69,7 @@ class Segment(SegmentProvider):
         )
 
     def __repr__(self) -> str:
-        return "{} segment: {}".format(
-            self.tag,
-            str(self.elements)
-        )
+        return "{} segment: {}".format(self.tag, str(self.elements))
 
     def __eq__(self, other) -> bool:
         # FIXME the other way round too? isinstance(other, type(self))?
@@ -132,8 +129,7 @@ class SegmentFactory:
         if type(name) != str:
             raise EDISyntaxError(
                 "The tag name of a segment must be a str, but is a {}: {}".format(
-                    type(name),
-                    name
+                    type(name), name
                 )
             )
 
@@ -155,9 +151,7 @@ class SegmentFactory:
         if validate:
             if not s.validate():
                 raise EDISyntaxError(
-                    "could not create '{}' Segment. Validation failed.".format(
-                        name
-                    )
+                    "could not create '{}' Segment. Validation failed.".format(name)
                 )
 
         # FIXME: characters is not used!


### PR DESCRIPTION
I'm working on a project which is (for now) pinned to Python 3.5, and I was hoping to use pydifact.

I just had to replace the fstrings with format calls instead, everything else so far seems fine (test suite passes, etc.)

As-per the docs I did run black as well, which has formatted code I did not write. I can back out these changes if you would like.