### PR TITLE
Do not longer use deprecated SegmentCollection in unit tests

### DIFF
--- a/tests/messagetypes/paxlst/test_unb.py
+++ b/tests/messagetypes/paxlst/test_unb.py
@@ -16,7 +16,7 @@
 import pytest
 
 from pydifact.control import Characters
-from pydifact.segmentcollection import SegmentCollection
+from pydifact.segmentcollection import RawSegmentCollection
 
 
 class Setup:
@@ -29,7 +29,7 @@ def setup():
     unb_segment = "UNB+UNOA:4+APIS*ABE+USADHS+070429:0900+000000001++USADHS'"
     cc = Characters()
     setup.cc = cc.with_control_character("decimal_point", ".")
-    setup.collection = SegmentCollection.from_str(unb_segment)
+    setup.collection = RawSegmentCollection.from_str(unb_segment)
     return setup
 
 

--- a/tests/test_huge_message.py
+++ b/tests/test_huge_message.py
@@ -13,13 +13,13 @@
 #
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from pydifact.segmentcollection import SegmentCollection
+from pydifact.segmentcollection import Interchange
 
 
 # This only a performance benchmark, no real test.
 def performance_test_huge_message():
     """Performance test parsing a huge message"""
-    collection = SegmentCollection.from_file("tests/data/huge_file2.edi")
+    collection = Interchange.from_file("tests/data/huge_file2.edi")
     assert collection
 
 

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -15,16 +15,16 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 
-from pydifact.segmentcollection import SegmentCollection
+from pydifact.segmentcollection import Interchange
 from pydifact.segments import Segment
 
 path = os.path.dirname(os.path.realpath(__file__)) + "/data"
 
 
 def test_wikipedia_file():
-    message = SegmentCollection.from_file("{}/wikipedia.edi".format(path))
+    message = Interchange.from_file("{}/wikipedia.edi".format(path))
     # make some checks
-    assert message.get_segment("UNB") == Segment(
+    assert message.get_header_segment() == Segment(
         "UNB", ["IATB", "1"], "6XPPC", "LHPPC", ["940101", "0950"], "1"
     )
     assert message.get_segment("IFT") == Segment("IFT", "3", "XYZCOMPANY AVAILABILITY")
@@ -34,9 +34,9 @@ def test_wikipedia_file():
 
 
 def test_invoice_file():
-    message = SegmentCollection.from_file("{}/invoice1.edi".format(path))
+    message = Interchange.from_file("{}/invoice1.edi".format(path))
     # make some checks
-    assert message.get_segment("UNB") == Segment(
+    assert message.get_header_segment() == Segment(
         "UNB",
         ["UNOA", "1"],
         "01010000253001",

--- a/tests/test_segmentcollection.py
+++ b/tests/test_segmentcollection.py
@@ -17,23 +17,23 @@ import datetime
 
 import pytest
 
-from pydifact.segmentcollection import Interchange, Message, SegmentCollection
+from pydifact.segmentcollection import Interchange, Message, RawSegmentCollection
 from pydifact.segments import Segment
 from pydifact.api import EDISyntaxError
 
 
 def test_from_file():
     with pytest.raises(FileNotFoundError):
-        SegmentCollection.from_file("/no/such/file")
+        Interchange.from_file("/no/such/file")
 
 
 def test_create_with_segments():
-    collection = SegmentCollection.from_segments([Segment("36CF")])
+    collection = RawSegmentCollection.from_segments([Segment("36CF")])
     assert [Segment("36CF")] == collection.segments
 
 
 def test_get_segments():
-    collection = SegmentCollection.from_segments(
+    collection = RawSegmentCollection.from_segments(
         [Segment("36CF", 1), Segment("CPD"), Segment("36CF", 2)]
     )
     segments = list(collection.get_segments("36CF"))
@@ -41,13 +41,13 @@ def test_get_segments():
 
 
 def test_get_segments_doesnt_exist():
-    collection = SegmentCollection()
+    collection = RawSegmentCollection()
     segments = list(collection.get_segments("36CF"))
     assert [] == segments
 
 
 def test_get_segments_w_predicate():
-    collection = SegmentCollection.from_segments(
+    collection = RawSegmentCollection.from_segments(
         [
             Segment("A", "1", "a"),
             Segment("A", "2", "b"),
@@ -62,7 +62,7 @@ def test_get_segments_w_predicate():
 
 
 def test_get_segment():
-    collection = SegmentCollection.from_segments(
+    collection = RawSegmentCollection.from_segments(
         [Segment("36CF", 1), Segment("36CF", 2)]
     )
     segment = collection.get_segment("36CF")
@@ -70,7 +70,7 @@ def test_get_segment():
 
 
 def test_get_segment_w_predicate():
-    collection = SegmentCollection.from_segments(
+    collection = RawSegmentCollection.from_segments(
         [Segment("36CF", "1"), Segment("36CF", "2")]
     )
     segment = collection.get_segment("36CF", lambda x: x[0] == "2")
@@ -78,7 +78,7 @@ def test_get_segment_w_predicate():
 
 
 def test_str_serialize():
-    collection = SegmentCollection.from_segments(
+    collection = RawSegmentCollection.from_segments(
         [Segment("36CF", "1"), Segment("36CF", "2")]
     )
     string = str(collection)
@@ -86,40 +86,40 @@ def test_str_serialize():
 
 
 def test_get_segment_doesnt_exist():
-    collection = SegmentCollection()
+    collection = RawSegmentCollection()
     segment = collection.get_segment("36CF")
     assert segment is None
 
 
 def test_empty_segment():
-    m = SegmentCollection()
+    m = RawSegmentCollection()
     m.add_segment(Segment("", []))
     assert m
 
 
 def test_malformed_tag1():
     with pytest.raises(EDISyntaxError):
-        SegmentCollection.from_str("IMD+F++:::This is 'a :malformed string'")
+        RawSegmentCollection.from_str("IMD+F++:::This is 'a :malformed string'")
 
 
 def test_malformed_tag2():
     with pytest.raises(EDISyntaxError):
-        SegmentCollection.from_str("IMD+F++:::This is '? :malformed string'")
+        RawSegmentCollection.from_str("IMD+F++:::This is '? :malformed string'")
 
 
 def test_malformed_tag3():
     with pytest.raises(EDISyntaxError):
-        SegmentCollection.from_str("IMD+F++:::This is '?? :malformed string'")
+        RawSegmentCollection.from_str("IMD+F++:::This is '?? :malformed string'")
 
 
 def test_malformed_tag4():
     with pytest.raises(EDISyntaxError):
-        SegmentCollection.from_str("IMD+F++:::This is '??:malformed string'")
+        RawSegmentCollection.from_str("IMD+F++:::This is '??:malformed string'")
 
 
 def test_malformed_tag5():
     with pytest.raises(EDISyntaxError):
-        SegmentCollection.from_str("IMD+F++:::This is '-:malformed string'")
+        RawSegmentCollection.from_str("IMD+F++:::This is '-:malformed string'")
 
 
 @pytest.fixture

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -14,9 +14,10 @@
 #    You should have received a copy of the GNU Lesser General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import copy
+import datetime
 import pytest
 
-from pydifact.segmentcollection import SegmentCollection
+from pydifact.segmentcollection import RawSegmentCollection, Interchange
 from pydifact.segments import Segment
 from pydifact.serializer import Serializer
 
@@ -26,6 +27,17 @@ def serializer():
     return Serializer()
 
 
+@pytest.fixture
+def interchange():
+    return Interchange(
+        sender="1234",
+        recipient="3333",
+        timestamp=datetime.datetime(2020, 1, 2, 22, 12),
+        control_reference="42",
+        syntax_identifier=("UNOC", 1),
+    )
+
+
 def assert_segments(serializer, expected: str, segments: list):
     """Helper function add default UNA header and terminator, and compare string to segment"""
     expected = "UNA:+,? '" + expected + "'"
@@ -33,22 +45,20 @@ def assert_segments(serializer, expected: str, segments: list):
     assert expected == collection
 
 
-def test_una_integrity1():
-    m = SegmentCollection()
+def test_una_integrity1(interchange):
     initstring = ":+,? '"
-    m.add_segment(Segment("UNA", initstring))
-    assert m.serialize() == "UNA" + initstring
+    interchange.add_segment(Segment("UNA", initstring))
+    assert interchange.serialize().startswith("UNA" + initstring)
 
 
-def test_UNA_integrity2():
-    m = SegmentCollection()
+def test_UNA_integrity2(interchange):
     initstring = ":+.? '"
-    m.add_segment(Segment("UNA", initstring))
-    assert m.serialize() == "UNA" + initstring
+    interchange.add_segment(Segment("UNA", initstring))
+    assert interchange.serialize().startswith("UNA" + initstring)
 
 
 def test_empty_segment_list():
-    m = SegmentCollection()
+    m = RawSegmentCollection()
     assert m.serialize() == ""
 
 


### PR DESCRIPTION
Pave the road for 0.2, but not yet breaking the API.

(and makes SegmentCollection untested, in favor of its substitutes).
