### PR TITLE
Fixed a missing newline after UNA element

### DIFF
--- a/pydifact/serializer.py
+++ b/pydifact/serializer.py
@@ -62,6 +62,8 @@ class Serializer:
                 return self.characters.service_string_advice
             else:
                 collection_parts += self.characters.service_string_advice
+                if break_lines:
+                    collection_parts += "\n"
 
         else:
             # no una header wanted!

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -45,6 +45,12 @@ def assert_segments(serializer, expected: str, segments: list):
     assert expected == collection
 
 
+def test_una_breakline(interchange):
+    initstring = ":+,? '"
+    interchange.add_segment(Segment("UNA", initstring))
+    assert interchange.serialize(break_lines=True).startswith("UNA" + initstring + "\n")
+
+
 def test_una_integrity1(interchange):
     initstring = ":+,? '"
     interchange.add_segment(Segment("UNA", initstring))


### PR DESCRIPTION
Issue: After the `UNA` element, a newline is missing, if line break is enabled.
