### PR TITLE
Fix: Interchange with extra header elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ prof
 .kdev4
 .venv*
 Pipfile.lock
+
+### VisualStudioCode ###
+.vscode/*
+
+# Local History for Visual Studio Code
+.history/

--- a/pydifact/segmentcollection.py
+++ b/pydifact/segmentcollection.py
@@ -530,6 +530,7 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
             recipient=unb.elements[2],
             timestamp=timestamp,
             control_reference=unb.elements[4],
+            extra_header_elements=unb.elements[5:]
         )
 
         if first_segment.tag == "UNA":

--- a/pydifact/segmentcollection.py
+++ b/pydifact/segmentcollection.py
@@ -530,7 +530,7 @@ class Interchange(FileSourcableMixin, UNAHandlingMixin, AbstractSegmentsContaine
             recipient=unb.elements[2],
             timestamp=timestamp,
             control_reference=unb.elements[4],
-            extra_header_elements=unb.elements[5:]
+            extra_header_elements=unb.elements[5:],
         )
 
         if first_segment.tag == "UNA":

--- a/tests/test_segmentcollection.py
+++ b/tests/test_segmentcollection.py
@@ -317,3 +317,23 @@ def test_counting_of_messages(interchange, message):
     )
     i = Interchange.from_str(edi_str)
     assert i.serialize() == edi_str
+
+
+def test_interchange_with_extra_header_elements():
+    edi_str = (
+        "UNB+UNOC:3+9901011000001:500+9900222000002:500+230314:1015+333333333++TL'"
+        "UNH+42z42+PAORES:93:1:IA'"
+        "UNT+2+42z42'"
+        "UNZ+1+333333333'"
+    )
+    i = Interchange.from_str(edi_str)
+    assert i.get_header_segment() == Segment(
+        "UNB",
+        ["UNOC", "3"],
+        ["9901011000001", "500"],
+        ["9900222000002", "500"],
+        ["230314", "1015"],
+        "333333333",
+        "",
+        "TL",
+    )


### PR DESCRIPTION
This PR applies a fix for parsing an interchange with extra header elements. Currently, any extra element is lost.

```python
def test_interchange_with_extra_header_elements():
    edi_str = (
        "UNB+UNOC:3+9901011000001:500+9900222000002:500+230314:1015+333333333++TL'"
        "UNH+42z42+PAORES:93:1:IA'"
        "UNT+2+42z42'"
        "UNZ+1+333333333'"
    )
    i = Interchange.from_str(edi_str)
    assert i.get_header_segment() == Segment(
        "UNB",
        ["UNOC", "3"],
        ["9901011000001", "500"],
        ["9900222000002", "500"],
        ["230314", "1015"],
        "333333333",
        "",
        "TL",
    )
```