### PR TITLE
Re-introduce the `py.typed` file marker

### DIFF
--- a/pydifact/py.typed
+++ b/pydifact/py.typed
@@ -1,0 +1,2 @@
+# This file marks mypackage as PEP561 compatible.
+# Further reading: https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages


### PR DESCRIPTION
Fixes #82