### PR TITLE
Remove stray mypy.fastparse import in EDSD parser

### DIFF
--- a/pydifact/generator/edsd.py
+++ b/pydifact/generator/edsd.py
@@ -4,8 +4,6 @@ from xml.etree import ElementTree
 from pathlib import Path
 from typing import List, Dict, Any
 
-from mypy.fastparse import Match
-
 from pydifact.generator.base import UntidBaseParser
 
 


### PR DESCRIPTION
## Summary

`pydifact/generator/edsd.py` imported `Match` from `mypy.fastparse`:

```python
from mypy.fastparse import Match
```

This broke importing the module at runtime — `mypy` is a dev-only
dependency (so it's absent in normal installs), and the symbol isn't
even exported from `mypy.fastparse`. Because `edsd` is imported by
`pydifact.generator.runner`, this also blocked the directory generator
entirely.

The imported `Match` name was never used: every `match` reference in the
file is a local `re.match(...)` result or a walrus assignment. The import
is therefore simply removed.

## Verification

- `import pydifact.generator.edsd` and `import pydifact.generator.runner`
  now succeed.
- Full test suite: **147 passed**.
- `black --check` clean.

https://claude.ai/code/session_01Q4NSyGd8CMCjjCH9gQCsvG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4NSyGd8CMCjjCH9gQCsvG)_